### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -85,7 +85,16 @@ const COMMANDS = {
       div.className = 'term-line';
       const out = document.createElement('span');
       out.className = 'term-out';
-      out.innerHTML = line;
+      if (typeof line === 'string') {
+        // Static lines may contain trusted HTML markup.
+        out.innerHTML = line;
+      } else if (line && line.type === 'error') {
+        // Render error message safely without interpreting user input as HTML.
+        const errSpan = document.createElement('span');
+        errSpan.className = 'error';
+        errSpan.textContent = line.message;
+        out.appendChild(errSpan);
+      }
       div.appendChild(out);
       body.appendChild(div);
     });
@@ -104,7 +113,7 @@ const COMMANDS = {
     if (fn) {
       print(fn(), cmd);
     } else {
-      print([`<span class="error">command not found: ${cmd}</span>`], cmd);
+      print([{ type: 'error', message: `command not found: ${cmd}` }], cmd);
     }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/6](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/6)

In general, the fix is to ensure that any user-controllable text is not inserted into the DOM using `innerHTML` (or similar HTML-parsing APIs) without proper escaping. Instead, construct DOM nodes using `textContent` for untrusted data, or escape meta-characters before interpolation into HTML.

The minimal, behavior-preserving fix here is:

1. Leave the trusted, static HTML snippets in `COMMANDS` as they are, still written with `innerHTML` (those are not user-controlled).
2. Change the place where `cmd` (user input) is interpolated into an error message so that `cmd` is added as text, not HTML.
3. Keep the `print` function interface intact so the rest of the code works as before; just avoid ever having a `line` value that contains unescaped user input mixed with HTML.

Concretely:

- In `run`, instead of constructing the error message as a full HTML string with template interpolation, pass a marker object (or a special type of value) to `print` that tells it to render a styled error while inserting `cmd` via `textContent`. However, since we cannot change the overall structure much, an even simpler fix is to have `run` pass a special “line object” and update `print` to handle both strings and objects.
- But to keep changes minimal, we can instead create the error line element inline in `run` and bypass `print` for that one case, or teach `print` to detect a specific sentinel value. To avoid changing call patterns too much, the cleanest change within the given snippet is: keep `print` but make it robust to non-string line entries, and for the error path, don't build HTML with the raw `cmd`; let `print` build the DOM safely.

To avoid complicating `print` too much and still maintain current external behavior, the practical fix:

- Change the error path in `run` to pass a structured object like `{ type: 'error', message: cmd }` instead of a string with embedded HTML.
- Adjust `print` to:
  - If `line` is a string, use the existing `innerHTML` behavior (for the static help / other built-in content).
  - If `line` is an object with `type === 'error'`, create a `<span class="error">` and set its `textContent` to `line.message`, then append it. This ensures untrusted `cmd` is never interpreted as HTML.

This keeps existing functionality (HTML formatting of static help lines) and prevents unescaped user input from reaching `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
