### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -72,7 +72,14 @@ const COMMANDS = {
     // echo typed command
     const echo = document.createElement('div');
     echo.className = 'term-line';
-    echo.innerHTML = `<span class="term-prompt-echo">${PROMPT}</span><span class="term-typed">${typed}</span>`;
+    const promptSpan = document.createElement('span');
+    promptSpan.className = 'term-prompt-echo';
+    promptSpan.textContent = PROMPT;
+    const typedSpan = document.createElement('span');
+    typedSpan.className = 'term-typed';
+    typedSpan.textContent = typed;
+    echo.appendChild(promptSpan);
+    echo.appendChild(typedSpan);
     body.appendChild(echo);
 
     if (lines === '__clear__') {


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/5](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/5)

General approach: avoid using `innerHTML` for any value that can contain user-supplied text. Instead, construct DOM nodes and assign untrusted data using `textContent`. Static, trusted HTML snippets may still use `innerHTML` if they are never influenced by user input.

Concretely here:

1. In `print`, change the echo line (line 75) so that we:
   - Create a container `div.term-line`.
   - Create a `span.term-prompt-echo` and set its `textContent` to `PROMPT`.
   - Create a `span.term-typed` and set its `textContent` to `typed`.
   - Append both spans to the container, then append the container to `body`.
   This removes the `innerHTML` call and ensures the typed command is treated purely as text.

2. Leave the rest of `print` intact:
   - The `COMMANDS` output lines are static strings intended to contain small HTML fragments; they can safely continue to use `innerHTML` since they are not derived from user input.
   - The error branch already uses `textContent` for `line.message` and is safe.

These changes are all inside `src/js/terminal.js`, within the existing `print` function around line 75. No new imports or external libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
