### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -40,7 +40,22 @@
         const lines = [];
         if (profile.name) lines.push(`${profile.name} / ${(profile.handle ?? '').replace(/^@/, '')}`);
         (profile.bio ?? []).forEach(b => lines.push(b));
-        const accounts = socialLinks.filter(l => l.url.includes('x.com'));
+        const allowedXHosts = new Set([
+          'x.com',
+          'www.x.com',
+          'twitter.com',
+          'www.twitter.com',
+          'mobile.twitter.com'
+        ]);
+        const accounts = socialLinks.filter(l => {
+          if (!l || !l.url) return false;
+          try {
+            const u = new URL(l.url, window.location.origin);
+            return allowedXHosts.has(u.hostname);
+          } catch (e) {
+            return false;
+          }
+        });
         if (accounts.length) {
           lines.push(accounts.map(l => `<a href="${l.url}" target="_blank" rel="noopener">@${l.url.split('/').pop()}</a>`).join(' · '));
         }


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/7](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/7)

In general, the fix is to stop using a substring search on the full URL string to determine whether it is an X/Twitter link, and instead parse the URL and compare its hostname against a whitelist of allowed hostnames (e.g., `x.com`, `www.x.com`, `twitter.com`, `mobile.twitter.com`, etc.). This ensures that only URLs whose actual host matches these values are treated as X accounts, and not URLs that merely contain `x.com` somewhere in the path, query, or as part of another domain name.

Concretely, within `src/js/terminal.js`, in the `whoami` command, replace:

```js
const accounts = socialLinks.filter(l => l.url.includes('x.com'));
```

with logic that: (1) safely constructs a `URL` object from `l.url` using the global `URL` class available in modern browsers; (2) extracts `url.host` (or `url.hostname`); and (3) checks this against a small set of allowed hostnames for X/Twitter. To avoid breaking existing functionality, we should still treat both `x.com` and `twitter.com` (and common subdomains like `www.` or `mobile.`) as valid. We also need to handle invalid URL strings defensively (e.g., wrap parsing in a `try/catch` and skip invalid entries). No additional imports are needed because `URL` is a standard Web API in the browser environment implied by the DOM usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
