### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -94,10 +94,11 @@
         createdQ = `+created:${since.slice(0,10)}..${until.slice(0,10)}`;
       }
       const periodLabel = year && month ? `${year}年${Number(month)}月` : '全期間';
+      const safeUsername = escHtml(username);
 
       appendLines([
         '',
-        `<span class="success">▶ 集計開始</span>  <span style="opacity:0.6">${username} / ${periodLabel}</span>`,
+        `<span class="success">▶ 集計開始</span>  <span style="opacity:0.6">${safeUsername} / ${periodLabel}</span>`,
         '<span style="opacity:0.3">────────────────────────────────────</span>',
       ], body);
 


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/10](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/10)

General approach: Either (a) stop using `innerHTML` for untrusted content and instead use `textContent` and DOM construction, or (b) ensure all untrusted content placed into HTML strings is contextually escaped before reaching `innerHTML`. Given the existing design where `appendLines` intentionally takes HTML snippets and uses `innerHTML`, the minimal, non-breaking change is to escape the `username` before interpolating it into the string on line 100.

Best concrete fix: In `runUserCount`, before building `periodLabel` / output lines, create a safe version of `username` using the existing `escHtml` helper (line 321), then use that escaped value in the interpolated HTML string. This preserves the existing formatting and behavior while preventing injection of HTML/JS via `username`. For example, `const safeUsername = escHtml(username);` then use `${safeUsername}` instead of `${username}` in the string on line 100. This change is self-contained within `runUserCount` and reuses existing functionality, so no new imports or dependencies are needed.

Specific changes:

- File: `src/js/terminal.js`
  - Within `runUserCount` (around line 87):
    - Add `const safeUsername = escHtml(username);` after computing `periodLabel`.
    - Update the line in `appendLines` (line 100) to use `${safeUsername}` rather than `${username}`.

No additional methods, imports, or definitions are required: `escHtml` is already defined earlier in the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
