### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete HTML attribute sanitization

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -245,6 +245,8 @@
 
     // ── Markdown ───────────────────────────────────────
     function escHtml(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+    // Attribute-safe HTML escaper (also escapes double quotes for use inside attributes)
+    function escAttr(s){return escHtml(s).replace(/"/g,'&quot;');}
     // javascript:/data:/vbscript: を除去して XSS を防ぐ
     function safeUrl(u){const t=u.trim();return/^(javascript|data|vbscript):/i.test(t)?'#':t;}
     function cleanUrl(url){url=url.replace(/\\([&()[\]#*_!])/g,'$1');url=url.replace(/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)/,'raw.githubusercontent.com/$1/$2/$3');return safeUrl(url);}
@@ -252,7 +254,7 @@
       md=md.replace(/\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g,(_,a,i,h)=>`<a href="${safeUrl(h)}" target="_blank" rel="noopener noreferrer"><img src="${cleanUrl(i)}" alt="${escHtml(a)}" class="readme-img"></a>`);
       md=md.replace(/!\[([^\]]*)\]\(([^)]+)\)/g,(_,a,s)=>`<img src="${cleanUrl(s)}" alt="${a}" class="readme-img">`);
       md=md.replace(/<a\s+href="([^"]*)"[^>]*>[\s\S]*?<img\s[^>]*src="([^"]*)"[^>]*\/?>[\s\S]*?<\/a>/gi,(_,h,s)=>`<a href="${safeUrl(h)}" target="_blank" rel="noopener noreferrer"><img src="${cleanUrl(s)}" class="readme-img"></a>`);
-      md=md.replace(/<img\s[^>]*src="([^"]*)"[^>]*\/?>/gi,(m,s)=>{if(m.includes('readme-img'))return m;const a=m.match(/alt="([^"]*)"/i);return`<img src="${cleanUrl(s)}" alt="${a?a[1]:''}" class="readme-img">`;});
+      md=md.replace(/<img\s[^>]*src="([^"]*)"[^>]*\/?>/gi,(m,s)=>{if(m.includes('readme-img'))return m;const a=m.match(/alt="([^"]*)"/i);const altText=a?a[1]:'';return`<img src="${cleanUrl(s)}" alt="${escAttr(altText)}" class="readme-img">`;});
       md=md.replace(/<a\s+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi,(m,h,inner)=>{if(inner.includes('<img'))return m;return`[${inner.trim()}](${safeUrl(h)})`;});
       md=md.replace(/<br\s*\/?>/gi,'\n');
       md=md.replace(/<(?!img\s|a\s[^>]*><img|\/a>)[^>]+(>|$)/gi,'');


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/12](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/12)

In general, when inserting untrusted data into an HTML attribute, you must escape double quotes (and ideally `&`, `<`, and `>` as well) for that attribute context. Here, the new `<img>` tag is built with a template literal that interpolates `a?a[1]:''` directly into the `alt` attribute, without any escaping of `"`. The best fix is to ensure the `alt` text is passed through an HTML-attribute-safe escaping function before interpolation, specifically escaping `"` (and `&`, `<`, `>`).

Concretely, in `src/js/terminal.js` inside `stripHtml`, we should:

1. Introduce a small helper that escapes for attribute context, e.g. `escAttr`, which can be implemented by reusing `escHtml` and then additionally replacing `"` with `&quot;`, or by doing all replacements in one function.
2. Use this helper when injecting `alt` text derived from the regex match in line 255: change `alt="${a?a[1]:''}"` to something like `alt="${escAttr(a ? a[1] : '')}"`.
3. Keep the rest of the logic intact so existing behavior is unchanged except for added safety.

All changes must be within `src/js/terminal.js` and within the shown snippets. We don’t need any external libraries; a local helper function is enough. The helper can be added next to `escHtml` to keep the code organized and reusable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
