### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete HTML attribute sanitization

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -251,7 +251,7 @@
     function safeUrl(u){const t=u.trim();return/^(javascript|data|vbscript):/i.test(t)?'#':t;}
     function cleanUrl(url){url=url.replace(/\\([&()[\]#*_!])/g,'$1');url=url.replace(/github\.com\/([^/]+)\/([^/]+)\/blob\/(.+)/,'raw.githubusercontent.com/$1/$2/$3');return safeUrl(url);}
     function stripHtml(md){
-      md=md.replace(/\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g,(_,a,i,h)=>`<a href="${safeUrl(h)}" target="_blank" rel="noopener noreferrer"><img src="${cleanUrl(i)}" alt="${escHtml(a)}" class="readme-img"></a>`);
+      md=md.replace(/\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g,(_,a,i,h)=>`<a href="${safeUrl(h)}" target="_blank" rel="noopener noreferrer"><img src="${cleanUrl(i)}" alt="${escAttr(a)}" class="readme-img"></a>`);
       md=md.replace(/!\[([^\]]*)\]\(([^)]+)\)/g,(_,a,s)=>`<img src="${cleanUrl(s)}" alt="${a}" class="readme-img">`);
       md=md.replace(/<a\s+href="([^"]*)"[^>]*>[\s\S]*?<img\s[^>]*src="([^"]*)"[^>]*\/?>[\s\S]*?<\/a>/gi,(_,h,s)=>`<a href="${safeUrl(h)}" target="_blank" rel="noopener noreferrer"><img src="${cleanUrl(s)}" class="readme-img"></a>`);
       md=md.replace(/<img\s[^>]*src="([^"]*)"[^>]*\/?>/gi,(m,s)=>{if(m.includes('readme-img'))return m;const a=m.match(/alt="([^"]*)"/i);const altText=a?a[1]:'';return`<img src="${cleanUrl(s)}" alt="${escAttr(altText)}" class="readme-img">`;});


### PR DESCRIPTION
Potential fix for [https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/11](https://github.com/hrmcngs/hrmc.ngs.computer/security/code-scanning/11)

In general, when inserting untrusted data into HTML attributes, the value must be escaped for attribute context: at a minimum `&`, `<`, `>`, and `"` (and often `'` as well if single-quoted attributes are used). Here, the project already defines `escHtml` (for generic text/HTML node context) and `escAttr` (which additionally escapes `"` for attribute context). The bug arises because `escHtml` is used where `escAttr` is needed.

The best fix, without changing existing functionality, is to update the string construction on line 254 so that the `alt` attribute uses `escAttr(a)` instead of `escHtml(a)`. That way, any double quotes in the `a` parameter are converted to `&quot;`, closing the XSS gap while preserving how the alt text renders. No other logic in `stripHtml` needs to change; we are only tightening the escaping for this one attribute use. All required helper functions (`escHtml`, `escAttr`) are already defined in `src/js/terminal.js`, so no new imports or definitions are needed.

Concretely:
- In `src/js/terminal.js`, inside the `stripHtml` function, locate the first `md=md.replace(/\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g, ...)` on or around line 254.
- Within the replacement template string, change `alt="${escHtml(a)}"` to `alt="${escAttr(a)}"`.
- Leave all other uses of `escHtml` and `escAttr` as they are.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
